### PR TITLE
Add Fedora Support + yum_repository directive

### DIFF
--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -10,7 +10,14 @@
   when: ansible_distribution == 'Fedora'
 
 - name: Add Appcanary repository
-  template: src=yum_repo dest=/etc/yum.repos.d/appcanary_agent.repo owner=root group=root mode=0644
+  yum_repository:
+    name: appcanary_agent
+    description: Appcanary Agent Repository
+    gpgkey: https://packagecloud.io/appcanary/agent/gpgkey
+    repo_gpgcheck: yes
+    gpgcheck: no
+    baseurl: "https://packagecloud.io/appcanary/agent/{{yum_distro}}/$releasever/$basearch"
+    enabled: yes
 
 - name: Update yum package cache
   shell: yum -q makecache -y --disablerepo='*' --enablerepo='appcanary_agent'

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -4,8 +4,13 @@
     - pygpgme
     - yum-utils
 
+- name: Assign Appcanary repository
+  set_fact:
+    yum_distro: fedora
+  when: ansible_distribution == 'Fedora'
+
 - name: Add Appcanary repository
-  copy: src=yum_repo dest=/etc/yum.repos.d/appcanary_agent.repo owner=root group=root mode=0644
+  template: src=yum_repo dest=/etc/yum.repos.d/appcanary_agent.repo owner=root group=root mode=0644
 
 - name: Update yum package cache
   shell: yum -q makecache -y --disablerepo='*' --enablerepo='appcanary_agent'

--- a/templates/yum_repo
+++ b/templates/yum_repo
@@ -1,10 +1,8 @@
-[appcanary_agent]
-name=appcanary_agent
-baseurl=https://packagecloud.io/appcanary/agent/{{yum_distro}}/$releasever/$basearch
-repo_gpgcheck=1
-gpgcheck=0
-enabled=1
-gpgkey=https://packagecloud.io/appcanary/agent/gpgkey
-sslverify=1
-sslcacert=/etc/pki/tls/certs/ca-bundle.crt
-metadata_expire=300
+[appcanary_agent][appcanary_agent]
+baseurl = https://packagecloud.io/appcanary/agent/{{yum_distro}}/$releasever/$basearch
+enabled = 1
+gpgcheck = 0
+gpgkey = https://packagecloud.io/appcanary/agent/gpgkey
+name = Appcanary Agent Repository
+repo_gpgcheck = 1
+

--- a/templates/yum_repo
+++ b/templates/yum_repo
@@ -1,6 +1,6 @@
 [appcanary_agent]
 name=appcanary_agent
-baseurl=https://packagecloud.io/appcanary/agent/el/$releasever/$basearch
+baseurl=https://packagecloud.io/appcanary/agent/{{yum_distro}}/$releasever/$basearch
 repo_gpgcheck=1
 gpgcheck=0
 enabled=1

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -1,2 +1,3 @@
 ---
 # vars file for ansible-appcanary
+yum_distro: el


### PR DESCRIPTION
This uses the Ansible 2.1 `yum_repository` command to reliably install the Yum/DNF repo.
