### PR TITLE
Fix undefined variable `monitored_files`.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,3 @@
 ---
-appcanary_files: []
+monitored_files: []
 monitor_system_packages: True


### PR DESCRIPTION
Change appcanary_files to monitored_files in defaults to prevent the following error when not setting the value in the role inclusion.

```
TASK [appcanary.agent : Upload appcanary config] *******************************
fatal: [database]: FAILED! => {"changed": false, "failed": true, "msg": "AnsibleUndefinedVariable: 'monitored_files' is undefined"}
```